### PR TITLE
Add visualization library & Fix versions to compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 numpy==1.26.4
 pandas==2.2.3
-scikit-learn==1.6.1
 alibi==0.9.6
 lime==0.2.0.1
 shap==0.46.0
 eli5==0.13.0
+lightgbm==4.5.0
+xgboost==2.1.3
+scikit-learn==1.2.2
+matplotlib==3.9.4
+seaborn==0.13.2


### PR DESCRIPTION
latest versions for xgboost, lightgbm
downgraded scikit-learn to 1.2.2 for compatibility with xgboost
downgraded numpy to 1.26.4 for compatibility with xai libraries, requiring version less than 2.0.0